### PR TITLE
components/Character: movable hand hitbox

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -22,3 +22,65 @@ export function logModelChildren(
     `world: (${worldPos.x.toFixed(3)}, ${worldPos.y.toFixed(3)}, ${worldPos.z.toFixed(3)})`,
   );
 }
+
+export function getBoneList(object: THREE.Object3D): THREE.Bone[] {
+  const boneList: THREE.Bone[] = [];
+
+  if (object instanceof THREE.Bone) {
+    boneList.push(object);
+  }
+
+  for (let i = 0; i < object.children.length; i++) {
+    boneList.push(...getBoneList(object.children[i]));
+  }
+
+  return boneList;
+}
+
+export interface BoneVertexMap {
+  [boneName: string]: number; // Maps bone name to vertex index in the position buffer
+}
+
+/**
+ * Creates a map from bone names to their vertex indices in the SkeletonHelper geometry.
+ * The SkeletonHelper creates 2 vertices per bone (parent position and bone position).
+ * Each bone with a Bone parent adds 2 vertices, so bone at index i has vertices at i*2 and i*2+1.
+ */
+export function makeBoneVertexMap(bones: THREE.Bone[]): BoneVertexMap {
+  const map: BoneVertexMap = {};
+  let vertexIndex = 0;
+
+  for (let i = 0; i < bones.length; i++) {
+    const bone = bones[i];
+
+    // SkeletonHelper only creates vertices for bones with a Bone parent
+    if (bone.parent && bone.parent instanceof THREE.Bone) {
+      // vertexIndex points to parent position, vertexIndex+1 points to bone position
+      map[bone.name] = vertexIndex + 1; // +1 to get the bone's own position (not parent)
+      vertexIndex += 2; // Each bone adds 2 vertices
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Gets the world position of a bone from the SkeletonHelper's geometry buffer.
+ * Call helper.update() before this to ensure positions are current.
+ */
+export function getBoneWorldPosition(
+  boneName: string,
+  boneVertexMap: BoneVertexMap,
+  positions: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+): THREE.Vector3 | null {
+  const vertexIndex = boneVertexMap[boneName];
+  if (vertexIndex === undefined) {
+    return null;
+  }
+
+  return new THREE.Vector3(
+    positions.getX(vertexIndex),
+    positions.getY(vertexIndex),
+    positions.getZ(vertexIndex),
+  );
+}

--- a/tests/component/Character.test.tsx
+++ b/tests/component/Character.test.tsx
@@ -35,6 +35,9 @@ jest.mock('@react-three/drei', () => {
 
 jest.mock('../../app/utils', () => ({
   getAnimation: jest.fn((model) => model.animations[0]),
+  getBoneList: jest.fn(() => []),
+  makeBoneVertexMap: jest.fn(() => ({})),
+  getBoneWorldPosition: jest.fn(() => null),
 }));
 
 jest.mock('three-stdlib', () => {


### PR DESCRIPTION
Previously, the hand collider was fixed in position. Now, we use the vertices from the SkeletonHelper to guide the collider with the bone's position.

Fixes: #10 