### PR TITLE
components/Player: clean up attack animation 

### DIFF
--- a/app/components/Player/Controls.tsx
+++ b/app/components/Player/Controls.tsx
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 
 import { SetKeyStateFn } from '@/app/components/Player/hooks/useKeyboardControls';
 import { useAnalogControls } from '@/app/components/Player/hooks/useAnalogControls';
-import { DebugSettings } from '@/app/components/hooks/useDebugSettings';
 import { CONTROLS_TEST_IDS } from '@/app/test-ids';
 
 export type { AnalogStickProps, OnscreenKeysProps, ControlsProps };
@@ -55,21 +54,13 @@ function AnalogStick({ updateKey }: AnalogStickProps) {
 
 interface OnscreenKeysProps {
   updateKey: SetKeyStateFn;
-  settings: DebugSettings;
 }
 
-function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
+function OnscreenKeys({ updateKey }: OnscreenKeysProps) {
   const smallButtonClass =
     'w-12 h-12 bg-gray-700 bg-opacity-80 border-1 border-gray-500 rounded-full flex items-center justify-center cursor-pointer select-none active:bg-gray-600 transition-colors text-white font-semibold text-xs';
   const largeButtonClass =
     'w-16 h-16 bg-gray-700 bg-opacity-80 border-1 border-gray-500 rounded-full flex items-center justify-center cursor-pointer select-none active:bg-gray-600 transition-colors text-white font-semibold text-sm';
-
-  // Helper function to handle mechanics key release with timeout
-  const handleMechanics = (key: 'q' | 'e' | 'p' | 'space') => {
-    setTimeout(() => {
-      updateKey(key, false);
-    }, settings.attackSpeed);
-  };
 
   return (
     <div
@@ -84,10 +75,10 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
           data-testid={CONTROLS_TEST_IDS.JUMP_BUTTON}
           aria-label="Jump"
           onMouseDown={() => updateKey('space', true)}
-          onMouseUp={() => handleMechanics('space')}
-          onMouseLeave={() => handleMechanics('space')}
+          onMouseUp={() => updateKey('space', false)}
+          onMouseLeave={() => updateKey('space', false)}
           onTouchStart={() => updateKey('space', true)}
-          onTouchEnd={() => handleMechanics('space')}
+          onTouchEnd={() => updateKey('space', false)}
         >
           Jump
         </button>
@@ -112,10 +103,10 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
           data-testid={CONTROLS_TEST_IDS.SPECIAL_BUTTON}
           aria-label="Special"
           onMouseDown={() => updateKey('e', true)}
-          onMouseUp={() => handleMechanics('e')}
-          onMouseLeave={() => handleMechanics('e')}
+          onMouseUp={() => updateKey('e', false)}
+          onMouseLeave={() => updateKey('e', false)}
           onTouchStart={() => updateKey('e', true)}
-          onTouchEnd={() => handleMechanics('e')}
+          onTouchEnd={() => updateKey('e', false)}
         >
           Special
         </button>
@@ -124,10 +115,10 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
           data-testid={CONTROLS_TEST_IDS.NORMAL_BUTTON}
           aria-label="Normal"
           onMouseDown={() => updateKey('q', true)}
-          onMouseUp={() => handleMechanics('q')}
-          onMouseLeave={() => handleMechanics('q')}
+          onMouseUp={() => updateKey('q', false)}
+          onMouseLeave={() => updateKey('q', false)}
           onTouchStart={() => updateKey('q', true)}
-          onTouchEnd={() => handleMechanics('q')}
+          onTouchEnd={() => updateKey('q', false)}
         >
           Normal
         </button>
@@ -136,10 +127,10 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
           data-testid={CONTROLS_TEST_IDS.ITEM_BUTTON}
           aria-label="Item"
           onMouseDown={() => updateKey('p', true)}
-          onMouseUp={() => handleMechanics('p')}
-          onMouseLeave={() => handleMechanics('p')}
+          onMouseUp={() => updateKey('p', false)}
+          onMouseLeave={() => updateKey('p', false)}
           onTouchStart={() => updateKey('p', true)}
-          onTouchEnd={() => handleMechanics('p')}
+          onTouchEnd={() => updateKey('p', false)}
         >
           Item
         </button>
@@ -150,10 +141,9 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
 
 interface ControlsProps {
   updateKey: SetKeyStateFn;
-  settings: DebugSettings;
 }
 
-function Controls({ updateKey, settings }: ControlsProps) {
+function Controls({ updateKey }: ControlsProps) {
   return (
     <>
       {/* Analog Stick */}
@@ -163,7 +153,7 @@ function Controls({ updateKey, settings }: ControlsProps) {
 
       {/* Onscreen Keys */}
       <div className="lg:hidden fixed bottom-1/12 right-1/12 z-50">
-        <OnscreenKeys updateKey={updateKey} settings={settings} />
+        <OnscreenKeys updateKey={updateKey} />
       </div>
     </>
   );

--- a/app/components/Player/Player.tsx
+++ b/app/components/Player/Player.tsx
@@ -162,7 +162,7 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
       if (specialAttackingRef.current && rigidBodyRef.current) {
         const pos = rigidBodyRef.current.translation();
         rigidBodyRef.current.setTranslation(
-          { x: pos.x + 1, y: pos.y, z: pos.z },
+          { x: pos.x + 0.4, y: pos.y, z: pos.z },
           true,
         );
       }
@@ -222,7 +222,7 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         const crouchAttackAction = m.clipAction(crouchAttackAnim);
         crouchAttackAction.reset();
         crouchAttackAction.setLoop(THREE.LoopOnce, 1);
-        crouchAttackAction.clampWhenFinished = false;
+        crouchAttackAction.clampWhenFinished = true;
 
         if (currentActionRef.current) {
           currentActionRef.current.fadeOut(0.1);
@@ -240,10 +240,12 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         normalAttackingRef.current = true;
         setNormalAttacking(true);
 
+        console.log(`d: ${delta}, normal: ${normalAttackingRef.current}`);
+
         const attackAction = m.clipAction(normalAnim);
         attackAction.reset();
         attackAction.setLoop(THREE.LoopOnce, 1);
-        attackAction.clampWhenFinished = false;
+        attackAction.clampWhenFinished = true;
 
         if (currentActionRef.current) {
           currentActionRef.current.fadeOut(0.1);
@@ -270,7 +272,7 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         const specialAction = m.clipAction(specialAnim);
         specialAction.reset();
         specialAction.setLoop(THREE.LoopOnce, 1);
-        specialAction.clampWhenFinished = false;
+        specialAction.clampWhenFinished = true;
 
         if (currentActionRef.current) {
           currentActionRef.current.fadeOut(0.1);
@@ -296,7 +298,7 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         const jumpAction = m.clipAction(jumpAnim);
         jumpAction.reset();
         jumpAction.setLoop(THREE.LoopOnce, 1);
-        jumpAction.clampWhenFinished = false;
+        jumpAction.clampWhenFinished = true;
 
         if (currentActionRef.current) {
           currentActionRef.current.fadeOut(0.1);
@@ -317,6 +319,7 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         const nextAction = m.clipAction(clip);
 
         if (currentActionRef.current !== nextAction) {
+          console.log(`d: ${delta}, normal: ${normalAttackingRef.current}`);
           nextAction.reset();
           nextAction.setLoop(THREE.LoopRepeat, Infinity);
           if (currentActionRef.current) {

--- a/app/components/Player/hooks/useKeyboardControls.tsx
+++ b/app/components/Player/hooks/useKeyboardControls.tsx
@@ -2,7 +2,6 @@
 import { useState, useCallback, useEffect } from 'react';
 
 import { CONTROLS_DEFAULTS } from '@/app/constants';
-import { DebugSettings } from '@/app/components/hooks/useDebugSettings';
 
 export type { KeyState, KeyHandlerFn, SetKeyStateFn };
 export { useKeyboardControls, isAttacking };
@@ -29,7 +28,7 @@ function isAttacking(keys: KeyState): boolean {
   return keys.q || keys.e;
 }
 
-function useKeyboardControls(settings: DebugSettings) {
+function useKeyboardControls() {
   const [keys, setKeys] = useState<KeyState>(CONTROLS_DEFAULTS.KEYBOARD);
 
   const updateKey = useCallback((key: keyof KeyState, value: boolean) => {
@@ -79,48 +78,37 @@ function useKeyboardControls(settings: DebugSettings) {
     (event: KeyboardEvent) => {
       const key = event.key.toLowerCase();
 
-      const keyUps = {
-        handleMove: (k: string) => {
-          switch (k) {
-            case 'w':
-              updateKey('w', false);
-              break;
-            case 'a':
-              updateKey('a', false);
-              break;
-            case 's':
-              updateKey('s', false);
-              break;
-            case 'd':
-              updateKey('d', false);
-              break;
-          }
-        },
-        handleMechanics: (k: string) => {
-          switch (k) {
-            case 'q':
-              updateKey('q', false);
-              break;
-            case 'e':
-              updateKey('e', false);
-              break;
-            case 'p':
-              updateKey('p', false);
-              break;
-            case ' ':
-              updateKey('space', false);
-              break;
-          }
-        },
-      };
-
-      if (key === 'control') {
-        updateKey('ctrl', false);
+      switch (key) {
+        case 'w':
+          updateKey('w', false);
+          break;
+        case 'a':
+          updateKey('a', false);
+          break;
+        case 's':
+          updateKey('s', false);
+          break;
+        case 'd':
+          updateKey('d', false);
+          break;
+        case 'q':
+          updateKey('q', false);
+          break;
+        case 'e':
+          updateKey('e', false);
+          break;
+        case 'p':
+          updateKey('p', false);
+          break;
+        case ' ':
+          updateKey('space', false);
+          break;
+        case 'control':
+          updateKey('ctrl', false);
+          break;
       }
-      keyUps.handleMove(key);
-      setTimeout(keyUps.handleMechanics, settings.attackSpeed, key);
     },
-    [updateKey, settings],
+    [updateKey],
   );
 
   useEffect(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ function createInitialBarbarians(): Record<string, boolean> {
 
 export default function Home() {
   const { settings, updateSettings } = useDebugSettings();
-  const { keys, updateKey } = useKeyboardControls(settings);
+  const { keys, updateKey } = useKeyboardControls();
   const [barbarians, setBarbarians] = useState<Record<string, boolean>>(
     createInitialBarbarians,
   );
@@ -81,7 +81,7 @@ export default function Home() {
           enableRotate={ENVIRONMENT_DEFAULTS.orbitControls.enableRotate}
         />
       </Canvas>
-      <Controls updateKey={updateKey} settings={settings} />
+      <Controls updateKey={updateKey} />
       <Button
         onClick={() => setDebugGuiHidden((prev) => !prev)}
         color="gray"

--- a/tests/component/Player/Controls.test.tsx
+++ b/tests/component/Player/Controls.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { expect, describe, it } from '@jest/globals';
 import {
   Controls,
@@ -7,28 +7,9 @@ import {
   OnscreenKeys,
 } from '@/app/components/Player/Controls';
 import { CONTROLS_TEST_IDS } from '@/app/test-ids';
-import { BARBARIAN_DEFAULTS } from '@/app/constants';
-import { DebugSettings } from '@/app/components/hooks/useDebugSettings';
 
 describe('Controls Component', () => {
   const mockUpdateKey = jest.fn();
-  const defaultSettings: DebugSettings = {
-    debugMode: false,
-    enableBarbarianWalk: BARBARIAN_DEFAULTS.enableBarbarianWalk,
-    barbarianWalkDurationMS: BARBARIAN_DEFAULTS.barbarianWalkDurationMS,
-    enableBarbarianAttack: BARBARIAN_DEFAULTS.enableBarbarianAttack,
-    attackSpeed: BARBARIAN_DEFAULTS.attackSpeed,
-    enableBarbarianJump: BARBARIAN_DEFAULTS.enableBarbarianJump,
-    jumpDurationMS: BARBARIAN_DEFAULTS.jumpDurationMS,
-    enableBarbarianLeftBlock: BARBARIAN_DEFAULTS.enableBarbarianLeftBlock,
-    blockDurationMS: BARBARIAN_DEFAULTS.blockDurationMS,
-    enableBarbarianRightBlock: BARBARIAN_DEFAULTS.enableBarbarianRightBlock,
-    rightBlockDurationMS: BARBARIAN_DEFAULTS.rightBlockDurationMS,
-    enableBarbarianKick: BARBARIAN_DEFAULTS.enableBarbarianKick,
-    kickSpeed: BARBARIAN_DEFAULTS.kickSpeed,
-    enableBarbarianDuck: BARBARIAN_DEFAULTS.enableBarbarianDuck,
-    duckDurationMS: BARBARIAN_DEFAULTS.duckDurationMS,
-  };
 
   beforeEach(() => {
     mockUpdateKey.mockClear();
@@ -36,7 +17,7 @@ describe('Controls Component', () => {
 
   describe('Controls', () => {
     it('should render AnalogStick and OnscreenKeys', () => {
-      render(<Controls updateKey={mockUpdateKey} settings={defaultSettings} />);
+      render(<Controls updateKey={mockUpdateKey} />);
 
       const analogStick = screen.getByTestId(CONTROLS_TEST_IDS.ANALOG_STICK);
       const onscreenKeys = screen.getByTestId(CONTROLS_TEST_IDS.ONSCREEN_KEYS);
@@ -64,9 +45,7 @@ describe('Controls Component', () => {
 
   describe('OnscreenKeys', () => {
     it('should render all action buttons', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
 
       const jumpButton = screen.getByTestId(CONTROLS_TEST_IDS.JUMP_BUTTON);
       const crouchButton = screen.getByTestId(CONTROLS_TEST_IDS.CROUCH_BUTTON);
@@ -84,9 +63,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with space true on jump button mouse down', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const jumpButton = screen.getByTestId(CONTROLS_TEST_IDS.JUMP_BUTTON);
 
       fireEvent.mouseDown(jumpButton);
@@ -94,25 +71,16 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with space false on jump button mouse up', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const jumpButton = screen.getByTestId(CONTROLS_TEST_IDS.JUMP_BUTTON);
 
       fireEvent.mouseUp(jumpButton);
 
-      waitFor(
-        () => {
-          expect(mockUpdateKey).toHaveBeenCalledWith('space', false);
-        },
-        { timeout: BARBARIAN_DEFAULTS.attackSpeed },
-      );
+      expect(mockUpdateKey).toHaveBeenCalledWith('space', false);
     });
 
     it('should call updateKey with q true on normal button mouse down', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const normalButton = screen.getByTestId(CONTROLS_TEST_IDS.NORMAL_BUTTON);
 
       fireEvent.mouseDown(normalButton);
@@ -120,9 +88,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with e true on special button mouse down', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const specialButton = screen.getByTestId(
         CONTROLS_TEST_IDS.SPECIAL_BUTTON,
       );
@@ -132,9 +98,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with p true on item button mouse down', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const itemButton = screen.getByTestId(CONTROLS_TEST_IDS.ITEM_BUTTON);
 
       fireEvent.mouseDown(itemButton);
@@ -142,9 +106,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with ctrl true on crouch button mouse down', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const crouchButton = screen.getByTestId(CONTROLS_TEST_IDS.CROUCH_BUTTON);
 
       fireEvent.mouseDown(crouchButton);
@@ -152,9 +114,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with ctrl false on crouch button mouse up', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const crouchButton = screen.getByTestId(CONTROLS_TEST_IDS.CROUCH_BUTTON);
 
       fireEvent.mouseUp(crouchButton);
@@ -162,9 +122,7 @@ describe('Controls Component', () => {
     });
 
     it('should call updateKey with ctrl false on crouch button mouse leave', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
       const crouchButton = screen.getByTestId(CONTROLS_TEST_IDS.CROUCH_BUTTON);
 
       fireEvent.mouseLeave(crouchButton);
@@ -172,9 +130,7 @@ describe('Controls Component', () => {
     });
 
     it('should have correct aria-labels for all buttons', () => {
-      render(
-        <OnscreenKeys updateKey={mockUpdateKey} settings={defaultSettings} />,
-      );
+      render(<OnscreenKeys updateKey={mockUpdateKey} />);
 
       expect(screen.getByLabelText('Jump')).toBeInTheDocument();
       expect(screen.getByLabelText('Crouch')).toBeInTheDocument();

--- a/tests/component/Player/useKeyboardControls.test.tsx
+++ b/tests/component/Player/useKeyboardControls.test.tsx
@@ -5,36 +5,17 @@ import {
   useKeyboardControls,
   isAttacking,
 } from '@/app/components/Player/hooks/useKeyboardControls';
-import { CONTROLS_DEFAULTS, BARBARIAN_DEFAULTS } from '@/app/constants';
-import { DebugSettings } from '@/app/components/hooks/useDebugSettings';
-
-const defaultSettings: DebugSettings = {
-  debugMode: false,
-  enableBarbarianWalk: BARBARIAN_DEFAULTS.enableBarbarianWalk,
-  barbarianWalkDurationMS: BARBARIAN_DEFAULTS.barbarianWalkDurationMS,
-  enableBarbarianAttack: BARBARIAN_DEFAULTS.enableBarbarianAttack,
-  attackSpeed: BARBARIAN_DEFAULTS.attackSpeed,
-  enableBarbarianJump: BARBARIAN_DEFAULTS.enableBarbarianJump,
-  jumpDurationMS: BARBARIAN_DEFAULTS.jumpDurationMS,
-  enableBarbarianLeftBlock: BARBARIAN_DEFAULTS.enableBarbarianLeftBlock,
-  blockDurationMS: BARBARIAN_DEFAULTS.blockDurationMS,
-  enableBarbarianRightBlock: BARBARIAN_DEFAULTS.enableBarbarianRightBlock,
-  rightBlockDurationMS: BARBARIAN_DEFAULTS.rightBlockDurationMS,
-  enableBarbarianKick: BARBARIAN_DEFAULTS.enableBarbarianKick,
-  kickSpeed: BARBARIAN_DEFAULTS.kickSpeed,
-  enableBarbarianDuck: BARBARIAN_DEFAULTS.enableBarbarianDuck,
-  duckDurationMS: BARBARIAN_DEFAULTS.duckDurationMS,
-};
+import { CONTROLS_DEFAULTS } from '@/app/constants';
 
 describe('useKeyboardControls Hook', () => {
   describe('Initialization', () => {
     it('should initialize with default keyboard state', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
       expect(result.current.keys).toEqual(CONTROLS_DEFAULTS.KEYBOARD);
     });
 
     it('should have all keys set to false initially', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
       const keys = result.current.keys;
 
       expect(keys.w).toBe(false);
@@ -51,7 +32,7 @@ describe('useKeyboardControls Hook', () => {
 
   describe('updateKey Function', () => {
     it('should update a specific key to true', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         result.current.updateKey('w', true);
@@ -61,7 +42,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should update a specific key to false', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         result.current.updateKey('w', true);
@@ -75,7 +56,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should update multiple keys independently', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         result.current.updateKey('w', true);
@@ -91,7 +72,7 @@ describe('useKeyboardControls Hook', () => {
 
   describe('Keyboard Event Handlers', () => {
     it('should set w key to true on W keydown', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         const event = new KeyboardEvent('keydown', { key: 'w' });
@@ -102,7 +83,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should set w key to false on W keyup', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }));
@@ -116,7 +97,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle uppercase W key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'W' }));
@@ -126,7 +107,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle A key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
@@ -136,7 +117,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle S key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }));
@@ -146,7 +127,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle D key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
@@ -156,7 +137,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle Q key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'q' }));
@@ -166,7 +147,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle E key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'e' }));
@@ -176,7 +157,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle P key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
@@ -186,7 +167,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle Space key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
@@ -196,7 +177,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle Control key', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control' }));
@@ -206,7 +187,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should set ctrl key to false on Control keyup immediately', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control' }));
@@ -220,7 +201,7 @@ describe('useKeyboardControls Hook', () => {
     });
 
     it('should handle multiple simultaneous keys', () => {
-      const { result } = renderHook(() => useKeyboardControls(defaultSettings));
+      const { result } = renderHook(() => useKeyboardControls());
 
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }));
@@ -234,9 +215,7 @@ describe('useKeyboardControls Hook', () => {
 
   describe('Event Cleanup', () => {
     it('should remove event listeners on unmount', () => {
-      const { unmount } = renderHook(() =>
-        useKeyboardControls(defaultSettings),
-      );
+      const { unmount } = renderHook(() => useKeyboardControls());
       const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 
       unmount();


### PR DESCRIPTION
Currently, there is a visible gap in the attack animation that affects the player experience. This is because the last frame in the animation does not have frame data so the default T-pose is briefly shown instead. This PR introduces a fix that avoids the problem by pausing the last frame. We also removed some unused code.

Fixes #90 