### PR TITLE
app/components/POVCamera: improve camera follow and controls

### DIFF
--- a/app/components/POVCamera.tsx
+++ b/app/components/POVCamera.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import { CAMERA_DEFAULTS } from '@/app/constants';
+
+const HEAD_Y_OFFSET = 0.75;
+const BEHIND_DIST = 2.2;
+const ABOVE_DIST = 0.9;
+const POS_LERP = 0.12;
+const ROT_SLERP = 0.12;
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+interface POVCameraProps {
+  playerPosRef: { current: THREE.Vector3 };
+  cameraYawRef: { current: number };
+}
+
+export function POVCamera({ playerPosRef, cameraYawRef }: POVCameraProps) {
+  const { camera, gl } = useThree();
+  const headPos = useRef(new THREE.Vector3());
+  const targetCamPos = useRef(new THREE.Vector3());
+  const targetQuat = useRef(new THREE.Quaternion());
+  const lookAtMatrix = useRef(new THREE.Matrix4());
+
+  useEffect(() => {
+    const canvas = gl.domElement;
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (document.pointerLockElement !== canvas) return;
+      cameraYawRef.current -= e.movementX * CAMERA_DEFAULTS.MOUSE_SENSITIVITY;
+      // Normalize to [-π, π]
+      cameraYawRef.current =
+        ((cameraYawRef.current + Math.PI) % (2 * Math.PI)) - Math.PI;
+    };
+
+    const onClick = () => {
+      canvas.requestPointerLock();
+    };
+
+    canvas.addEventListener('click', onClick);
+    document.addEventListener('mousemove', onMouseMove);
+
+    return () => {
+      canvas.removeEventListener('click', onClick);
+      document.removeEventListener('mousemove', onMouseMove);
+      if (document.pointerLockElement === canvas) {
+        document.exitPointerLock();
+      }
+    };
+  }, [gl, cameraYawRef]);
+
+  useFrame(() => {
+    const yaw = cameraYawRef.current;
+
+    headPos.current.set(
+      playerPosRef.current.x,
+      playerPosRef.current.y + HEAD_Y_OFFSET,
+      playerPosRef.current.z,
+    );
+
+    const fx = Math.sin(yaw);
+    const fz = Math.cos(yaw);
+
+    targetCamPos.current.set(
+      headPos.current.x - fx * BEHIND_DIST,
+      headPos.current.y + ABOVE_DIST,
+      headPos.current.z - fz * BEHIND_DIST,
+    );
+
+    camera.position.lerp(targetCamPos.current, POS_LERP);
+
+    lookAtMatrix.current.lookAt(camera.position, headPos.current, UP);
+    targetQuat.current.setFromRotationMatrix(lookAtMatrix.current);
+    camera.quaternion.slerp(targetQuat.current, ROT_SLERP);
+  });
+
+  return null;
+}

--- a/app/components/Player/Controls.tsx
+++ b/app/components/Player/Controls.tsx
@@ -5,9 +5,10 @@ import { SetKeyStateFn } from '@/app/components/Player/hooks/useKeyboardControls
 import { useAnalogControls } from '@/app/components/Player/hooks/useAnalogControls';
 import { DebugSettings } from '@/app/components/hooks/useDebugSettings';
 import { CONTROLS_TEST_IDS } from '@/app/test-ids';
+import { CAMERA_DEFAULTS } from '@/app/constants';
 
 export type { AnalogStickProps, OnscreenKeysProps, ControlsProps };
-export { AnalogStick, OnscreenKeys, Controls };
+export { AnalogStick, OnscreenKeys, Controls, LookZone };
 
 interface AnalogStickProps {
   updateKey: SetKeyStateFn;
@@ -148,14 +149,49 @@ function OnscreenKeys({ updateKey, settings }: OnscreenKeysProps) {
   );
 }
 
+interface LookZoneProps {
+  cameraYawRef: { current: number };
+}
+
+function LookZone({ cameraYawRef }: LookZoneProps) {
+  const lastTouchXRef = useRef<number | null>(null);
+
+  return (
+    <div
+      className="lg:hidden fixed top-0 right-0 w-1/2 h-full z-40"
+      style={{ touchAction: 'none' }}
+      data-testid={CONTROLS_TEST_IDS.LOOK_ZONE}
+      onTouchStart={(e) => {
+        lastTouchXRef.current = e.touches[0].clientX;
+      }}
+      onTouchMove={(e) => {
+        e.preventDefault();
+        if (lastTouchXRef.current === null) return;
+        const dx = e.touches[0].clientX - lastTouchXRef.current;
+        cameraYawRef.current -= dx * CAMERA_DEFAULTS.TOUCH_SENSITIVITY;
+        cameraYawRef.current =
+          ((cameraYawRef.current + Math.PI) % (2 * Math.PI)) - Math.PI;
+        lastTouchXRef.current = e.touches[0].clientX;
+      }}
+      onTouchEnd={() => {
+        lastTouchXRef.current = null;
+      }}
+    />
+  );
+}
+
 interface ControlsProps {
   updateKey: SetKeyStateFn;
   settings: DebugSettings;
+  cameraYawRef?: { current: number };
 }
 
-function Controls({ updateKey, settings }: ControlsProps) {
+function Controls({ updateKey, settings, cameraYawRef }: ControlsProps) {
   return (
     <>
+      {/* Camera look zone (mobile right-side touch drag) */}
+      {cameraYawRef && <LookZone cameraYawRef={cameraYawRef} />}
+
       {/* Analog Stick */}
       <div className="lg:hidden fixed bottom-1/12 left-1/12 z-50">
         <AnalogStick updateKey={updateKey} />

--- a/app/components/Player/Player.tsx
+++ b/app/components/Player/Player.tsx
@@ -29,12 +29,19 @@ interface PlayerProps {
   keys: KeyState;
   onHit?: () => void;
   settings: DebugSettings;
+  playerPosRef?: { current: THREE.Vector3 };
+  cameraYawRef?: { current: number };
 }
 
-export function Player({ keys, onHit, settings }: PlayerProps) {
+export function Player({
+  keys,
+  onHit,
+  settings,
+  playerPosRef,
+  cameraYawRef,
+}: PlayerProps) {
   const rigidBodyRef = useRef<RapierRigidBody>(null);
   const modelRef = useRef<THREE.Group>(null);
-  const lastRotationRef = useRef<number>(Math.PI / 2);
   const [torsoPosition, setTorsoPosition] = useState<[number, number, number]>([
     ...SHARED_DEFAULTS.COLLIDERS.TORSO.position,
   ]);
@@ -409,6 +416,12 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
     }
 
     if (rigidBodyRef.current) {
+      if (playerPosRef) {
+        const t = rigidBodyRef.current.translation();
+        playerPosRef.current.set(t.x, t.y, t.z);
+      }
+
+      const yaw = cameraYawRef?.current ?? Math.PI / 2;
       const moveSpeed = SHARED_DEFAULTS.MOVE_SPEED;
       const velocity = { x: 0, y: 0, z: 0 };
 
@@ -420,50 +433,45 @@ export function Player({ keys, onHit, settings }: PlayerProps) {
         !crouchAttackingRef.current &&
         !specialAttackingRef.current
       ) {
-        // WASD movement with rotation to face direction
+        // Camera-relative WASD movement
+        const fwdX = Math.sin(yaw);
+        const fwdZ = Math.cos(yaw);
+        const rightX = Math.cos(yaw);
+        const rightZ = -Math.sin(yaw);
+
         if (keys.w) {
-          velocity.z = -moveSpeed;
+          velocity.x += fwdX * moveSpeed;
+          velocity.z += fwdZ * moveSpeed;
         }
         if (keys.s) {
-          velocity.z = moveSpeed;
+          velocity.x -= fwdX * moveSpeed;
+          velocity.z -= fwdZ * moveSpeed;
         }
         if (keys.a) {
-          velocity.x = -moveSpeed;
-          rigidBodyRef.current.setRotation(
-            { x: 0, y: -0.707, z: 0, w: 0.707 },
-            true,
-          ); // Face -X
-          lastRotationRef.current = -Math.PI / 2;
+          velocity.x += rightX * moveSpeed;
+          velocity.z += rightZ * moveSpeed;
         }
         if (keys.d) {
-          velocity.x = moveSpeed;
-          rigidBodyRef.current.setRotation(
-            { x: 0, y: 0.707, z: 0, w: 0.707 },
-            true,
-          ); // Face +X
-          lastRotationRef.current = Math.PI / 2;
+          velocity.x -= rightX * moveSpeed;
+          velocity.z -= rightZ * moveSpeed;
         }
 
-        // Apply last horizontal rotation when moving vertically without horizontal input
-        if ((keys.w || keys.s) && !keys.a && !keys.d) {
-          const halfAngle = lastRotationRef.current / 2;
-          rigidBodyRef.current.setRotation(
-            { x: 0, y: Math.sin(halfAngle), z: 0, w: Math.cos(halfAngle) },
-            true,
-          );
+        // Normalize diagonal movement to keep consistent speed
+        const speed = Math.sqrt(velocity.x ** 2 + velocity.z ** 2);
+        if (speed > moveSpeed) {
+          velocity.x = (velocity.x / speed) * moveSpeed;
+          velocity.z = (velocity.z / speed) * moveSpeed;
         }
       }
 
       rigidBodyRef.current.setLinvel(velocity, true);
 
-      // When idle, maintain last rotation
-      if (!moving) {
-        const halfAngle = lastRotationRef.current / 2;
-        rigidBodyRef.current.setRotation(
-          { x: 0, y: Math.sin(halfAngle), z: 0, w: Math.cos(halfAngle) },
-          true,
-        );
-      }
+      // Player model always faces camera direction
+      const halfAngle = yaw / 2;
+      rigidBodyRef.current.setRotation(
+        { x: 0, y: Math.sin(halfAngle), z: 0, w: Math.cos(halfAngle) },
+        true,
+      );
     }
   });
 

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -194,3 +194,8 @@ export const LEVA_THEMES = {
     },
   },
 };
+
+export const CAMERA_DEFAULTS = {
+  MOUSE_SENSITIVITY: 0.002,
+  TOUCH_SENSITIVITY: 0.004,
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
+import { POVCamera } from '@/app/components/POVCamera';
+import * as THREE from 'three';
 import { Physics } from '@react-three/rapier';
 import { Player } from '@/app/components/Player/Player';
 import { Barbarian } from '@/app/components/Barbarian/Barbarian';
@@ -25,6 +26,8 @@ function createInitialBarbarians(): Record<string, boolean> {
 }
 
 export default function Home() {
+  const playerPosRef = useRef(new THREE.Vector3(-1, 0.9, 0));
+  const cameraYawRef = useRef(Math.PI / 2);
   const { settings, updateSettings } = useDebugSettings();
   const { keys, updateKey } = useKeyboardControls(settings);
   const [barbarians, setBarbarians] = useState<Record<string, boolean>>(
@@ -72,16 +75,22 @@ export default function Home() {
         />
         <Physics gravity={[0, 0, 0]} debug={settings.debugMode}>
           {barbarianComponents}
-          <Player keys={keys} onHit={handlePlayerHit} settings={settings} />
+          <Player
+            keys={keys}
+            onHit={handlePlayerHit}
+            settings={settings}
+            playerPosRef={playerPosRef}
+            cameraYawRef={cameraYawRef}
+          />
         </Physics>
         <World />
-        <OrbitControls
-          enableZoom={ENVIRONMENT_DEFAULTS.orbitControls.enableZoom}
-          enablePan={ENVIRONMENT_DEFAULTS.orbitControls.enablePan}
-          enableRotate={ENVIRONMENT_DEFAULTS.orbitControls.enableRotate}
-        />
+        <POVCamera playerPosRef={playerPosRef} cameraYawRef={cameraYawRef} />
       </Canvas>
-      <Controls updateKey={updateKey} settings={settings} />
+      <Controls
+        updateKey={updateKey}
+        settings={settings}
+        cameraYawRef={cameraYawRef}
+      />
       <Button
         onClick={() => setDebugGuiHidden((prev) => !prev)}
         color="gray"

--- a/app/test-ids.ts
+++ b/app/test-ids.ts
@@ -6,4 +6,5 @@ export const CONTROLS_TEST_IDS = {
   NORMAL_BUTTON: 'normal-button',
   ITEM_BUTTON: 'item-button',
   CROUCH_BUTTON: 'crouch-button',
+  LOOK_ZONE: 'look-zone',
 };

--- a/tests/component/Player/Controls.test.tsx
+++ b/tests/component/Player/Controls.test.tsx
@@ -5,6 +5,7 @@ import {
   Controls,
   AnalogStick,
   OnscreenKeys,
+  LookZone,
 } from '@/app/components/Player/Controls';
 import { CONTROLS_TEST_IDS } from '@/app/test-ids';
 import { BARBARIAN_DEFAULTS } from '@/app/constants';
@@ -181,6 +182,79 @@ describe('Controls Component', () => {
       expect(screen.getByLabelText('Special')).toBeInTheDocument();
       expect(screen.getByLabelText('Normal')).toBeInTheDocument();
       expect(screen.getByLabelText('Item')).toBeInTheDocument();
+    });
+  });
+
+  describe('LookZone', () => {
+    it('should render look zone when cameraYawRef is provided', () => {
+      const cameraYawRef = { current: Math.PI / 2 };
+      render(
+        <Controls
+          updateKey={mockUpdateKey}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
+      );
+      expect(
+        screen.getByTestId(CONTROLS_TEST_IDS.LOOK_ZONE),
+      ).toBeInTheDocument();
+    });
+
+    it('should not render look zone when cameraYawRef is not provided', () => {
+      render(<Controls updateKey={mockUpdateKey} settings={defaultSettings} />);
+      expect(
+        screen.queryByTestId(CONTROLS_TEST_IDS.LOOK_ZONE),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should decrease cameraYawRef when dragging right', () => {
+      const cameraYawRef = { current: Math.PI / 2 };
+      render(<LookZone cameraYawRef={cameraYawRef} />);
+      const lookZone = screen.getByTestId(CONTROLS_TEST_IDS.LOOK_ZONE);
+
+      fireEvent.touchStart(lookZone, {
+        touches: [{ clientX: 200, clientY: 300 }],
+      });
+      fireEvent.touchMove(lookZone, {
+        touches: [{ clientX: 300, clientY: 300 }],
+      });
+
+      // Dragging right (dx=100) should decrease yaw
+      expect(cameraYawRef.current).toBeLessThan(Math.PI / 2);
+    });
+
+    it('should increase cameraYawRef when dragging left', () => {
+      const cameraYawRef = { current: Math.PI / 2 };
+      render(<LookZone cameraYawRef={cameraYawRef} />);
+      const lookZone = screen.getByTestId(CONTROLS_TEST_IDS.LOOK_ZONE);
+
+      fireEvent.touchStart(lookZone, {
+        touches: [{ clientX: 300, clientY: 300 }],
+      });
+      fireEvent.touchMove(lookZone, {
+        touches: [{ clientX: 200, clientY: 300 }],
+      });
+
+      // Dragging left (dx=-100) should increase yaw
+      expect(cameraYawRef.current).toBeGreaterThan(Math.PI / 2);
+    });
+
+    it('should reset tracking on touch end', () => {
+      const cameraYawRef = { current: Math.PI / 2 };
+      render(<LookZone cameraYawRef={cameraYawRef} />);
+      const lookZone = screen.getByTestId(CONTROLS_TEST_IDS.LOOK_ZONE);
+
+      fireEvent.touchStart(lookZone, {
+        touches: [{ clientX: 200, clientY: 300 }],
+      });
+      fireEvent.touchEnd(lookZone, { touches: [] });
+
+      // A subsequent move should not update yaw (no active drag)
+      const yawAfterEnd = cameraYawRef.current;
+      fireEvent.touchMove(lookZone, {
+        touches: [{ clientX: 300, clientY: 300 }],
+      });
+      expect(cameraYawRef.current).toBe(yawAfterEnd);
     });
   });
 });

--- a/tests/component/Player/Player.test.tsx
+++ b/tests/component/Player/Player.test.tsx
@@ -197,23 +197,16 @@ describe('Player Component', () => {
       mockSetRotation.mockClear();
     });
 
-    it('should set negative Z velocity when W key is pressed', async () => {
+    it('should set camera-forward velocity when W key is pressed', async () => {
+      // At yaw=0: sin(0)=0, cos(0)=1 → forward = +Z (exact IEEE 754 values)
       const movingKeys = { ...mockKeys, w: true };
+      const cameraYawRef = { current: 0 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
-      );
-      await renderer.advanceFrames(1, 1 / 60);
-
-      expect(mockSetLinvel).toHaveBeenCalledWith(
-        { x: 0, y: 0, z: -SHARED_DEFAULTS.MOVE_SPEED },
-        true,
-      );
-    });
-
-    it('should set positive Z velocity when S key is pressed', async () => {
-      const movingKeys = { ...mockKeys, s: true };
-      const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
@@ -223,28 +216,59 @@ describe('Player Component', () => {
       );
     });
 
-    it('should set negative X velocity when A key is pressed', async () => {
-      const movingKeys = { ...mockKeys, a: true };
+    it('should set camera-backward velocity when S key is pressed', async () => {
+      // At yaw=0: backward = -Z
+      const movingKeys = { ...mockKeys, s: true };
+      const cameraYawRef = { current: 0 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
       expect(mockSetLinvel).toHaveBeenCalledWith(
-        { x: -SHARED_DEFAULTS.MOVE_SPEED, y: 0, z: 0 },
+        { x: 0, y: 0, z: -SHARED_DEFAULTS.MOVE_SPEED },
         true,
       );
     });
 
-    it('should set positive X velocity when D key is pressed', async () => {
-      const movingKeys = { ...mockKeys, d: true };
+    it('should set camera-left strafe velocity when A key is pressed', async () => {
+      // At yaw=0: rightX=cos(0)=1, rightZ=-sin(0)=0 → left strafe = +X
+      const movingKeys = { ...mockKeys, a: true };
+      const cameraYawRef = { current: 0 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
       expect(mockSetLinvel).toHaveBeenCalledWith(
         { x: SHARED_DEFAULTS.MOVE_SPEED, y: 0, z: 0 },
+        true,
+      );
+    });
+
+    it('should set camera-right strafe velocity when D key is pressed', async () => {
+      // At yaw=0: right strafe = -X
+      const movingKeys = { ...mockKeys, d: true };
+      const cameraYawRef = { current: 0 };
+      const renderer = await create(
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
+      );
+      await renderer.advanceFrames(1, 1 / 60);
+
+      expect(mockSetLinvel).toHaveBeenCalledWith(
+        { x: -SHARED_DEFAULTS.MOVE_SPEED, y: 0, z: 0 },
         true,
       );
     });
@@ -316,30 +340,42 @@ describe('Player Component', () => {
       );
     });
 
-    it('should rotate to face -X when A key is pressed', async () => {
+    it('should always face camera direction when A key is pressed', async () => {
       const movingKeys = { ...mockKeys, a: true };
+      const cameraYawRef = { current: Math.PI / 2 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
-      // A key should rotate to face -X direction
+      // Player always faces cameraYaw regardless of movement key
+      const halfAngle = Math.PI / 4;
       expect(mockSetRotation).toHaveBeenCalledWith(
-        { x: 0, y: -0.707, z: 0, w: 0.707 },
+        { x: 0, y: Math.sin(halfAngle), z: 0, w: Math.cos(halfAngle) },
         true,
       );
     });
 
-    it('should rotate to face +X when D key is pressed', async () => {
+    it('should always face camera direction when D key is pressed', async () => {
       const movingKeys = { ...mockKeys, d: true };
+      const cameraYawRef = { current: Math.PI / 2 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
-      // D key should rotate to face +X direction
+      // Player always faces cameraYaw regardless of movement key
+      const halfAngle = Math.PI / 4;
       expect(mockSetRotation).toHaveBeenCalledWith(
-        { x: 0, y: 0.707, z: 0, w: 0.707 },
+        { x: 0, y: Math.sin(halfAngle), z: 0, w: Math.cos(halfAngle) },
         true,
       );
     });
@@ -375,14 +411,19 @@ describe('Player Component', () => {
 
     it('should allow movement when not attacking', async () => {
       const movingKeys = { ...mockKeys, w: true, q: false };
+      const cameraYawRef = { current: 0 };
       const renderer = await create(
-        <Player keys={movingKeys} settings={defaultSettings} />,
+        <Player
+          keys={movingKeys}
+          settings={defaultSettings}
+          cameraYawRef={cameraYawRef}
+        />,
       );
       await renderer.advanceFrames(1, 1 / 60);
 
-      // Not attacking, so movement should work
+      // Not attacking, so movement should work (W = camera forward = +Z at yaw 0)
       expect(mockSetLinvel).toHaveBeenCalledWith(
-        { x: 0, y: 0, z: -SHARED_DEFAULTS.MOVE_SPEED },
+        { x: 0, y: 0, z: SHARED_DEFAULTS.MOVE_SPEED },
         true,
       );
     });


### PR DESCRIPTION
Make camera follow the player smoothly and keep them centered for a more natural gameplay view. Add mouse/touch look control and update movement to be camera-relative. Fix direction for keyboard and joystick.

Fixes #102